### PR TITLE
Remove trailing whitespace in source files

### DIFF
--- a/lib/Template/Plugin/XML/Feed.pm
+++ b/lib/Template/Plugin/XML/Feed.pm
@@ -12,7 +12,7 @@ sub new {
 
   return $class->fail('No filename specified')
     unless $filename;
-    
+
   my $feed = XML::Feed->parse($filename)
     or return $class->error('failed to create XML::Feed');
 
@@ -30,7 +30,7 @@ Template::Plugin::XML::Feed - Plugin interface to XML::Feed
 =head1 SYNOPSIS
 
     [% USE news = XML.Feed('news.rdf') %]
-   
+
     [% FOREACH item IN news.items %]
        [% item.title %]
        [% item.link  %]
@@ -52,12 +52,12 @@ from the plugin object using the familiar dotted compound notation:
 
     [% news.channel.title  %]
     [% news.channel.link   %]
-    [% news.channel.etc... %]  
+    [% news.channel.etc... %]
 
     [% news.image.title    %]
     [% news.image.url      %]
     [% news.image.link     %]
-    [% news.image.etc...   %]  
+    [% news.image.etc...   %]
 
 The list of news items can be retrieved using the 'items' method:
 

--- a/t/rss.t
+++ b/t/rss.t
@@ -11,7 +11,7 @@ skip_all('XML::Feed') if $@;
 
 # account for script being run in distribution root or 't' directory
 my $file = abs_path( -d 't' ? 't/xml' : 'xml' );
-$file .= '/example.rdf';   
+$file .= '/example.rdf';
 
 open my $rss_fh, '<', $file or die "Can't open $file: $!";
 my $data = do { local $/; <$rss_fh> };


### PR DESCRIPTION
Some projects consider removing trailing whitespace to be a must, and some see it simply as nit-picking. Either way, I noticed this issue while reading the source code and thought you might like to use the change.  If you don't see it as necessary, I'm happy with this PR being closed unmerged.