### PR TITLE
Bump copyright year to match most recent release

### DIFF
--- a/lib/Template/Plugin/XML/Feed.pm
+++ b/lib/Template/Plugin/XML/Feed.pm
@@ -84,7 +84,7 @@ by Dave Cross.
 
 =head1 COPYRIGHT AND LICENCE
 
-Copyright (C) 2009-2020 Magnum Solutions Ltd.  All Rights Reserved.
+Copyright (C) 2009-2021 Magnum Solutions Ltd.  All Rights Reserved.
 
 This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.


### PR DESCRIPTION
I noticed that the copyright year didn't match the year of the most recent release, hence I updated the copyright statement to match.

This PR is submitted in the hope that it is useful; if you want anything changed, please just let me know and I'll be happy to update and resubmit as necessary.