### PR TITLE
Specify the minimum Perl version explicitly

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -7,6 +7,7 @@ my $build = Module::Build->new(
   requires           => {
     Template => 0,
     XML::Feed => 0,
+    perl => 5.006,
   },
   build_requires     => {
     Test::More => 0,

--- a/lib/Template/Plugin/XML/Feed.pm
+++ b/lib/Template/Plugin/XML/Feed.pm
@@ -2,6 +2,7 @@ package Template::Plugin::XML::Feed;
 
 use strict;
 use warnings;
+use 5.006;
 use base 'Template::Plugin';
 use XML::Feed;
 


### PR DESCRIPTION
I noticed that `Perl::MinimumVersion` showed that no minimum version was
set explicitly and that the minimum Perl version required for this dist
was version 5.6.  This change specifies the version requirement
explicitly in the module itself as well as in the `Build.PL` script so
that the version requirement can be checked at build time.  This change
also corrects the `meta_yml_declares_perl_version` CPANTS issue.

If you'd like anything changed with this PR, please don't hesitate to let me know! I'm more than happy to update and resubmit as necessary.