### PR TITLE
Fix GitHub action builds on Windows

### DIFF
--- a/.github/workflows/perltest.yml
+++ b/.github/workflows/perltest.yml
@@ -13,11 +13,11 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
+  build-unix:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-latest']
         perl: [ 'latest' ]
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
@@ -27,5 +27,17 @@ jobs:
         with:
           perl-version: ${{ matrix.perl }}
       - run: perl -V
-      - run: cpanm --installdeps .
+      - run: cpanm --installdeps . || { cat $HOME/.cpanm/build.log ; false ; }
+      - run: prove -lv t
+  build-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['windows-latest']
+        perl: [ 'latest' ]
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: perl -V
+      - run: cpanm --installdeps . || &{ type $HOME\.cpanm\build.log ; perl -e "exit 1" ; }
       - run: prove -lv t


### PR DESCRIPTION
I noticed that the GitHub workflow for Windows was failing and decided
to work out why.  The build logs showed that `Module::Pluggable` was
failing its tests, which seemed rather odd.  After much wailing and
knashing of teeth (not really), I worked out that the
`shogo82148/actions-setup-perl@v1` was causing the problem.  Exactly *why*
it was causing this problem is unclear; nevertheless, omitting this
action for the Windows-based builds enabled all of the dependencies to
be installed via `cpanm --installdeps .`

Since the `shogo82148/actions-setup-perl@v1` action was causing the
problem, it seemd best to split the jobs into two: one for the
Unix-based builds and one for the Windows-based builds.  I've also added
more debugging output to the `cpanm` calls so that if some dependency
*does* fail in the future, then the detailed build information will also
be present as part of the GitHub action's build log.

If you want me to change anything in this PR, please just let me know and I'll be happy to update and resubmit!